### PR TITLE
Fix getShifts()

### DIFF
--- a/src/shiftplanning.php
+++ b/src/shiftplanning.php
@@ -1003,12 +1003,15 @@ class shiftplanning
 		);
 	}
 
-	public function getShifts( )
+	public function getShifts( $shift_filters = array( ) )
 	{// get shifts
 		return $this->setRequest(
-			array(
-				'module' => 'schedule.shifts',
-				'method' => 'GET'
+			array_merge(
+				array(
+					'module' => 'schedule.shifts',
+					'method' => 'GET'
+				),
+				$shift_filters
 			)
 		);
 	}


### PR DESCRIPTION
The get shift method will not return anything without parameters (even though the documentation says only token is required). See this post for confirmation from shiftplanning: http://www.shiftplanning.com/forums/viewtopic.php?id=45369. Allowed parameters to be passed through getShifts
